### PR TITLE
add s3 bucket name in xblock edit settings

### DIFF
--- a/s3uploader_downloader/s3uploader_downloader.py
+++ b/s3uploader_downloader/s3uploader_downloader.py
@@ -58,6 +58,7 @@ class UploaderDownloaderXBlock(XBlock):
         context["uploadable_by_students"] = self.uploadable_by_students
         context['size_limit'] = self.size_limit
         context['paginate'] = self.paginate
+        context['s3_bucket'] = self.s3_bucket or ''
 
         if(context["uploadable_by_students"]==True):
             context["check_uploadable_by_students"] = "checked"
@@ -84,6 +85,7 @@ class UploaderDownloaderXBlock(XBlock):
         self.uploadable_by_students = data.get('uploadable_by_students')
         self.size_limit = data.get('size_limit')
         self.paginate = data.get('paginate')
+        self.s3_bucket = data.get('s3_bucket')
 
         return {'result': 'success'}
 
@@ -114,7 +116,8 @@ class UploaderDownloaderXBlock(XBlock):
                         "aws_key":settings.AWS_ACCESS_KEY_ID,
                         "unit_id":unit_id,
                         "s3_mid_folder":self.s3_mid_folder,
-			"course_level":course_level,
+                        "s3_bucket": self.s3_bucket,
+                        "course_level":course_level,
                         "general_title":self.general_title,
                         "size_limit":self.size_limit,
                         "bin_icon":self.runtime.local_resource_url(self, 'static/img/bin.png'),
@@ -169,11 +172,11 @@ class UploaderDownloaderXBlock(XBlock):
         if data.get('success', None):
             return self.make_response(200)
         else:
-            request_payload = data 
+            request_payload = data
             headers = request_payload.get('headers', None)
             if headers:
-                # The presence of the 'headers' property in the request payload 
-                # means this is a request to sign a REST/multipart request 
+                # The presence of the 'headers' property in the request payload
+                # means this is a request to sign a REST/multipart request
                 # and NOT a policy document
                 response_data = self.sign_headers(headers)
             else:
@@ -326,7 +329,7 @@ class UploaderDownloaderXBlock(XBlock):
 
     def is_valid_policy(self, policy_document):
         """ Verify the policy document has not been tampered with client-side
-        before sending it off. 
+        before sending it off.
         """
         bucket = ''
         parsed_max_size = 0

--- a/s3uploader_downloader/s3uploader_downloader.py
+++ b/s3uploader_downloader/s3uploader_downloader.py
@@ -42,7 +42,7 @@ class UploaderDownloaderXBlock(XBlock):
     uploadable_by_students = Boolean(default=False, scope=Scope.settings)
     size_limit = Integer(default=10,scope=Scope.content,help="Number of recordings on one page")
     paginate = Integer(default=20,scope=Scope.content)
-    s3_bucket = String(default='public-sgu', scope=Scope.settings)
+    s3_bucket = String(default=settings.AWS_STORAGE_BUCKET_NAME, scope=Scope.settings)
 
     def resource_string(self, path):
         """Handy helper for getting resources from our kit."""

--- a/s3uploader_downloader/static/html/s3uploader_downloader_edit.html
+++ b/s3uploader_downloader/static/html/s3uploader_downloader_edit.html
@@ -16,6 +16,13 @@
     </li>
     <li class="field comp-setting-entry is-set">
       <div class="wrapper-comp-setting">
+        <label class="label setting-label" for="s3_bucket">S3 Bucket Name</label>
+        <input class="input setting-input" name="s3_bucket" id="s3_bucket" type="text" value="{{s3_bucket}}" />
+      </div>
+      <span class="tip setting-help">Make sure you have this bucket created on AWS.</span>
+    </li>
+    <li class="field comp-setting-entry is-set">
+      <div class="wrapper-comp-setting">
         <label class="label setting-label" for="uploadable_by">Uploadable by</label>
           <input type="radio" name="uploadable_by" id="uploadable_by_staff" style="height: inherit;width: inherit;" {{check_uploadable_by_staff}}>
           <label style="padding-right: 100px;">Staff</label>

--- a/s3uploader_downloader/static/js/src/s3uploader_downloader_edit.js
+++ b/s3uploader_downloader/static/js/src/s3uploader_downloader_edit.js
@@ -7,11 +7,12 @@ function s3UploaderDownloaderEditBlock(runtime, element) {
     var data = {
       general_title: $(element).find('input[name=general_title]').val(),
       s3_mid_folder: $(element).find('input[name=s3_mid_folder]').val(),
+      s3_bucket: $(element).find('input[name=s3_bucket]').val(),
       uploadable_by_students : $(element).find('input[id=uploadable_by_students]')[0].checked,
       size_limit : $(element).find('input[id=size_limit]').val(),
       paginate : $(element).find('input[id=paginate]').val()
     };
-    
+
     runtime.notify('save', {state: 'start'});
 
     console.log("===========");


### PR DESCRIPTION
Fixes #5

As a learner when I tried to upload a file I got a `403 error.` Upon investigation, I came to know that the default bucket name `public-sgu` doesn't exist in my storage, which is a default `s3_bucket` name added in the code. However, I couldn't find a way to configure this name via settings from the studio as I can edit other settings.

The default bucket name will be picked from settings instead of a hardcoded name.
This PR is intended to add `s3_bucket` in settings in studio view so the instructor can provide his/her own preferred bucket name.